### PR TITLE
* Refactor ListDifferenceBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.0.17 / 2015-07-07
+========
+  * Refactor ListDifferenceBuilder
+  * Breaking change, LDB now takes 2 arguments instead of 3 and the output of the #build method is an array of AR objects rather than a hash.
+  * Add CHANGELOG.md
+
 0.0.16 / 2015-06-29
 ========
   * Fix bug with ListDifferenceBuilder route_to method

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    xing-backend (0.0.15)
+    xing-backend (0.0.17)
       active_model_serializers (~> 0.9.3)
       i18n (~> 0.7)
       rails (~> 4.2.1)

--- a/lib/xing/builders/ordered_list_difference_builder.rb
+++ b/lib/xing/builders/ordered_list_difference_builder.rb
@@ -8,11 +8,10 @@ module Xing
           mapper = @mapper_class.new(item[:incoming], item[:locator])
 
           # Sets association, attributes and position
-          @collection << mapper.record
           mapper.perform_mapping
           set_position(mapper.record, index)
 
-          @new_list << mapper
+          @new_list << mapper.record
           @errors[index] = mapper.errors[:data] unless mapper.errors[:data].blank?
         end
       end

--- a/spec/deprecated_classes/list_difference_builder_spec.rb
+++ b/spec/deprecated_classes/list_difference_builder_spec.rb
@@ -14,6 +14,6 @@ describe ListDifferenceBuilder, :type => :deprecation do
   end
 
   it "should be the correct class" do
-    expect(ListDifferenceBuilder.new(list_data, collection, mapper)).to be_a(Xing::Builders::OrderedListDifferenceBuilder)
+    expect(ListDifferenceBuilder.new(list_data, mapper)).to be_a(Xing::Builders::OrderedListDifferenceBuilder)
   end
 end

--- a/spec/xing/builders/list_difference_builder_spec.rb
+++ b/spec/xing/builders/list_difference_builder_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Xing::Builders::ListDifferenceBuilder do
 
   let :builder do
-    Xing::Builders::ListDifferenceBuilder.new(list_data, collection, mapper_class)
+    Xing::Builders::ListDifferenceBuilder.new(list_data, mapper_class)
   end
 
   let :mapper_class do
@@ -14,20 +14,12 @@ describe Xing::Builders::ListDifferenceBuilder do
     double("mapper")
   end
 
-  let :collection do
-    [double("Relation AR Object id: 1"), double("Relation AR Object id: 2"), double("Relation AR Object id: 3")]
-  end
-
   let :new_ar_object do
     double("New Relation AR Object")
   end
 
   let :updated_ar_object do
     double("Updated AR Object")
-  end
-
-  let :existing_ids do
-    [1,2,3]
   end
 
   let :list_data do
@@ -78,30 +70,14 @@ describe Xing::Builders::ListDifferenceBuilder do
     ]
   end
 
-  it "should initialize and assign list_data, collection, mapper class and errors" do
-    expect(builder.instance_variable_get('@list_data')).to eq(list_data)
-    expect(builder.instance_variable_get('@collection')).to eq(collection)
-    expect(builder.instance_variable_get('@mapper_class')).to eq(mapper_class)
-    expect(builder.instance_variable_get('@errors')).to eq({})
-  end
-
   describe "#sort_json_items" do
     before :each do
-      allow(collection).to receive(:map).and_return(existing_ids)
       allow(builder).to receive(:locator_for).and_return(1)
       builder.sort_json_items
     end
 
-    it "should create a list of existing ids" do
-      expect(builder.instance_variable_get('@existing_ids')).to eq(existing_ids)
-    end
-
     it "should insert index and locator into the item data" do
       expect(builder.instance_variable_get('@list_data')).to eq(new_list_data)
-    end
-
-    it "should find the ids to delete" do
-      expect(builder.instance_variable_get('@delete_ids')).to eq([2,3])
     end
   end
 
@@ -129,7 +105,7 @@ describe Xing::Builders::ListDifferenceBuilder do
     before :each do
       builder.instance_variable_set('@list_data', new_list_data)
       allow(mapper_class).to receive(:new).and_return(mapper_instance)
-      allow(mapper_instance).to receive(:record).and_return(new_ar_object, new_ar_object, updated_ar_object, updated_ar_object)
+      allow(mapper_instance).to receive(:record).and_return(new_ar_object, updated_ar_object)
       allow(mapper_instance).to receive(:perform_mapping)
       allow(new_ar_object).to receive(:has_attribute?).with(:position).and_return(false)
       allow(updated_ar_object).to receive(:has_attribute?).with(:position).and_return(false)
@@ -140,7 +116,7 @@ describe Xing::Builders::ListDifferenceBuilder do
         allow(mapper_instance).to receive(:errors).and_return({})
         builder.map_items
 
-        expect(builder.instance_variable_get('@new_list')).to match_array([mapper_instance, mapper_instance])
+        expect(builder.instance_variable_get('@new_list')).to match_array([new_ar_object, updated_ar_object])
       end
     end
 
@@ -156,10 +132,9 @@ describe Xing::Builders::ListDifferenceBuilder do
 
   describe "#build" do
     before :each do
-      allow(collection).to receive(:map).and_return(existing_ids)
       allow(builder).to receive(:locator_for).and_return(1)
       allow(mapper_class).to receive(:new).and_return(mapper_instance)
-      allow(mapper_instance).to receive(:record).and_return(new_ar_object, new_ar_object, updated_ar_object, updated_ar_object)
+      allow(mapper_instance).to receive(:record).and_return(new_ar_object, updated_ar_object)
       allow(mapper_instance).to receive(:perform_mapping)
       allow(new_ar_object).to receive(:has_attribute?).with(:position).and_return(false)
       allow(updated_ar_object).to receive(:has_attribute?).with(:position).and_return(false)
@@ -171,11 +146,7 @@ describe Xing::Builders::ListDifferenceBuilder do
       end
 
       it "should return a hash with save keys" do
-        expect(builder.build[:save]).to match_array([mapper_instance, mapper_instance])
-      end
-
-      it "should return a hash with delete keys" do
-        expect(builder.build[:delete]).to match_array([2,3])
+        expect(builder.build).to match_array([new_ar_object, updated_ar_object])
       end
     end
 

--- a/spec/xing/builders/ordered_list_difference_builder_spec.rb
+++ b/spec/xing/builders/ordered_list_difference_builder_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Xing::Builders::OrderedListDifferenceBuilder do
 
   let :builder do
-    Xing::Builders::OrderedListDifferenceBuilder.new(list_data, collection, mapper_class)
+    Xing::Builders::OrderedListDifferenceBuilder.new(list_data, mapper_class)
   end
 
   let :mapper_class do
@@ -14,20 +14,12 @@ describe Xing::Builders::OrderedListDifferenceBuilder do
     double("mapper")
   end
 
-  let :collection do
-    [double("Relation AR Object id: 1"), double("Relation AR Object id: 2"), double("Relation AR Object id: 3")]
-  end
-
   let :new_ar_object do
     double("New Relation AR Object")
   end
 
   let :updated_ar_object do
     double("Updated AR Object")
-  end
-
-  let :existing_ids do
-    [1,2,3]
   end
 
   let :list_data do
@@ -78,30 +70,14 @@ describe Xing::Builders::OrderedListDifferenceBuilder do
     ]
   end
 
-  it "should initialize and assign list_data, collection, mapper class and errors" do
-    expect(builder.instance_variable_get('@list_data')).to eq(list_data)
-    expect(builder.instance_variable_get('@collection')).to eq(collection)
-    expect(builder.instance_variable_get('@mapper_class')).to eq(mapper_class)
-    expect(builder.instance_variable_get('@errors')).to eq({})
-  end
-
   describe "#sort_json_items" do
     before :each do
-      allow(collection).to receive(:map).and_return(existing_ids)
       allow(builder).to receive(:locator_for).and_return(1)
       builder.sort_json_items
     end
 
-    it "should create a list of existing ids" do
-      expect(builder.instance_variable_get('@existing_ids')).to eq(existing_ids)
-    end
-
     it "should insert index and locator into the item data" do
       expect(builder.instance_variable_get('@list_data')).to eq(new_list_data)
-    end
-
-    it "should find the ids to delete" do
-      expect(builder.instance_variable_get('@delete_ids')).to eq([2,3])
     end
   end
 
@@ -140,7 +116,7 @@ describe Xing::Builders::OrderedListDifferenceBuilder do
         allow(mapper_instance).to receive(:errors).and_return({})
         builder.map_items
 
-        expect(builder.instance_variable_get('@new_list')).to match_array([mapper_instance, mapper_instance])
+        expect(builder.instance_variable_get('@new_list')).to match_array([new_ar_object, updated_ar_object])
       end
     end
 
@@ -173,7 +149,6 @@ describe Xing::Builders::OrderedListDifferenceBuilder do
 
   describe "#build" do
     before :each do
-      allow(collection).to receive(:map).and_return(existing_ids)
       allow(builder).to receive(:locator_for).and_return(1)
       allow(mapper_class).to receive(:new).and_return(mapper_instance)
       allow(mapper_instance).to receive(:record).and_return(new_ar_object, new_ar_object, updated_ar_object, updated_ar_object)
@@ -188,11 +163,7 @@ describe Xing::Builders::OrderedListDifferenceBuilder do
       end
 
       it "should return a hash with save keys" do
-        expect(builder.build[:save]).to match_array([mapper_instance, mapper_instance])
-      end
-
-      it "should return a hash with delete keys" do
-        expect(builder.build[:delete]).to match_array([2,3])
+        expect(builder.build).to match_array([new_ar_object, updated_ar_object])
       end
     end
 

--- a/xing-backend.gemspec
+++ b/xing-backend.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name		= "xing-backend"
-  spec.version		= "0.0.16"
+  spec.version		= "0.0.17"
   author_list = {
     "Evan Dorn" => 'evan@lrdesign.com',
     "Patricia Ho" => 'patricia@lrdesign.com',


### PR DESCRIPTION
- Breaking change, LDB now takes 2 arguments instead of 3 and the output of the #build method is an array of AR objects rather than a hash.
- Add CHANGELOG.md
